### PR TITLE
Fixing #64.

### DIFF
--- a/features/servers/minecraft.feature
+++ b/features/servers/minecraft.feature
@@ -23,6 +23,7 @@ Feature: Minecraft server management
       | 127.0.0.1 | testing1 | id_rsa1 | Team 1    |
       | 127.0.0.1 | testing2 | id_rsa2 | SubTeam 1 |
       | 127.0.0.1 | testing3 | id_rsa3 | Team 2    |
+      | 127.0.0.1 | testing4 | id_rsa4 |           |
       | 127.0.0.1 | bugged   |         | SubTeam 1 |
     And there are following games:
       | name      | installName | launchName | bin                  | type      | available |
@@ -59,7 +60,7 @@ Feature: Minecraft server management
       And I am on the minecraft index page
      When I follow "Ajouter un serveur Minecraft"
      Then I should be on the minecraft creation page
-      And I should see 4 "machine" options in "dedipanel_minecraft" form
+      And I should see 5 "machine" options in "dedipanel_minecraft" form
 
   Scenario: Accessing the minecraft creation form as team admin
     Given I am logged in with baz account
@@ -109,6 +110,29 @@ Feature: Minecraft server management
       And I should see 2 success message
       And I should see "Le serveur minecraft a bien été ajouté."
       And I should see "L'installation de votre serveur est terminé."
+      And I should see "Test4"
+
+  Scenario: Adding a minecraft server with a super-admin account
+    Given I am logged in with foo account
+      And I am on the minecraft creation page
+     When I fill in dedipanel_minecraft form with:
+      | machine      | testing4         |
+      | name         | Test Super-Admin |
+      | port         | 25565            |
+      | queryPort    | 25565            |
+      | rconPort     | 25575            |
+      | rconPassword | test5            |
+      | game         | minecraft        |
+      | dir          | test5            |
+      | maxplayers   | 2                |
+      | minHeap      | 128              |
+      | maxHeap      | 256              |
+      And I press "Créer"
+     Then I should be on the minecraft index page
+      And I should see 2 success message
+      And I should see "Le serveur minecraft a bien été ajouté."
+      And I should see "L'installation de votre serveur est terminé."
+      And I should see "Test Super-Admin"
 
   Scenario: Adding an existing minecraft server
     Given I am logged in with boz account

--- a/src/DP/Core/CoreBundle/Behat/ResourceContext.php
+++ b/src/DP/Core/CoreBundle/Behat/ResourceContext.php
@@ -119,7 +119,12 @@ class ResourceContext extends SyliusDefaultContext
     {
         foreach ($table->getHash() as $data) {
             $groups = isset($data['groups']) ? $data['groups'] : $data['group'];
-            $groups = array_map('trim', explode(',', $groups));
+
+            if (!empty($groups)) {
+                $groups = array_map('trim', explode(',', $groups));
+            } else {
+                $groups = [];
+            }
 
             $this->thereIsMachine(
                 $data['username'],

--- a/src/DP/Core/CoreBundle/Controller/Server/ServerDomainManager.php
+++ b/src/DP/Core/CoreBundle/Controller/Server/ServerDomainManager.php
@@ -240,6 +240,8 @@ class ServerDomainManager extends DomainManager
      * Finalize a server installation
      *
      * @param ServerInterface $server
+     *
+     * @return boolean
      */
     protected function finalizeInstall(ServerInterface $server)
     {

--- a/src/DP/Core/UserBundle/EventListener/UserAdminListener.php
+++ b/src/DP/Core/UserBundle/EventListener/UserAdminListener.php
@@ -38,10 +38,9 @@ class UserAdminListener
     public function onKernelController(FilterControllerEvent $event)
     {
         $request = $event->getRequest();
+        $_sylius = $request->attributes->get('_sylius');
 
-        if ($request->attributes->get('_route') == static::USER_INDEX
-        && $this->context->isGranted(User::ROLE_SUPER_ADMIN)) {
-            $_sylius = $request->attributes->get('_sylius');
+        if ($this->context->isGranted(User::ROLE_SUPER_ADMIN) && isset($_sylius['criteria']['groups'])) {
             unset($_sylius['criteria']['groups']);
 
             $request->attributes->set('_sylius', $_sylius);

--- a/src/DP/Core/UserBundle/Tests/Service/UserGroupResolverTest.php
+++ b/src/DP/Core/UserBundle/Tests/Service/UserGroupResolverTest.php
@@ -114,9 +114,9 @@ class UserGroupResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($groups, $this->resolver->getAccessibleGroups());
     }
 
-    public function testGettingAccessibleGroupsWhenErroredUser()
+    public function testGettingAccessibleGroupsWhithErroredUser()
     {
-        $this->context->expects($this->exactly(2))
+        $this->context->expects($this->exactly(3))
             ->method('isGranted')
             ->will($this->returnValue(false));
         $this->groupRepo->expects($this->never())
@@ -124,6 +124,8 @@ class UserGroupResolverTest extends \PHPUnit_Framework_TestCase
         $this->user->expects($this->once())
             ->method('getGroup')
             ->will($this->returnValue(null));
+
+        $this->setExpectedException('\RuntimeException', 'Security error! This user should not have empty group access. This can lead to security breach.');
 
         $this->assertEmpty($this->resolver->getAccessibleGroups());
     }


### PR DESCRIPTION
* Deleting the `groups` criteria from routing for super-admin user, in order to display all servers (also those who are not assigned to a specific group).